### PR TITLE
Add design doc

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -1,0 +1,40 @@
+# Design Document
+
+This document captures the design decisions made after dicussion in issues. When a design issue is closed, the
+conclusion should be summarized here with a link to the issue.
+
+## Disk Layout
+
+Originally discussed in issue #18
+
+### Summary:
+
+ - FCOS will use a "dd-able" image and ship with a standard parition layout.
+ - The bare metal image and cloud images have the same layout.
+ - Anaconda will not be used for installation.
+ - FCOS should not use the [GPT generator](https://www.freedesktop.org/software/systemd/man/systemd-gpt-auto-generator.html).
+ - LVM should be supported, but not used by default.
+ - Ignition will be used to customize disk layouts.
+
+FCOS should have a fixed partition layout that Ignition can modify on first boot. The installer will be similar to the
+Container Linux installer; the core of it will be dd'ing an image to the disk.
+
+The partition layout is still undecided, but initial proposals look something like:
+
+    Number	Type	Purpose
+    -----------------------------------
+    1	fat32	Boot partition/ESP
+    2	N/A	Bios Boot partition
+    3	ext4?	Root
+    4	ext4?	/var
+
+We also want to support moving the root partition to new locations by recreating the OSTree at the new location. This
+would involve downloading the OSTree repo contents and doing the deploy between the Ignition disks and files stage if
+the root filesystem has changed. This is currently untested.
+
+### Open Questions:
+
+ - What do we do about 4k sector disks? We could make a "hybrid" disk image, but it technically breaks the GPT spec and
+   may not work with poorly implemeted UEFIs.
+ - What is the exact partition layout?
+ - Do we make /etc a ro bind mount?


### PR DESCRIPTION
Please check for:
 - Grammar, clarity, etc
 - That I accurately recorded the discussion
 - Formatting seems good

I only did the partitioning issue. We can add summaries of other closed issues in more PRs.

I envision that when we want to close out an issue, we PR this doc with a summary. Once we agree the PR is good and accurately encapsulates the discussion, we merge the PR and close the issue.

As the doc grows we may want to break it out into multiple docs in a directory, but that can come later.

Finally, I'd prefer to keep this doc about design of FCOS itself and not about the process around it. We can have a seperate doc for that (the README does a great job right now) if we want.