### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+<!--
+If reporting a bug in Fedore CoreOS, please include the
+output of `rpm-ostree status`.
+-->


### PR DESCRIPTION
We're crafting an operating system with a transactional image-like
update mechanism. Let's take advantage of this by asking reporters to
include their `rpm-ostree status` in issue reports.