### PR TITLE
Add files to track our AWS IAM permissions

### DIFF
--- a/notes/aws-iam-policies/prod-account/fcos-poc-artifacts
+++ b/notes/aws-iam-policies/prod-account/fcos-poc-artifacts
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "s3:PutObjectAcl",
+            "Resource": [
+                "arn:aws:s3:::fcos-builds/*",
+                "arn:aws:s3:::fcos-builds"
+            ]
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": [
+                "arn:aws:s3:::fcos-builds/*",
+                "arn:aws:s3:::fcos-builds"
+            ]
+        }
+    ]
+}

--- a/notes/aws-iam-policies/prod-account/fcos-upload-amis
+++ b/notes/aws-iam-policies/prod-account/fcos-upload-amis
@@ -12,6 +12,7 @@
                 "ec2:ImportSnapshot",
                 "ec2:CopyImage",
                 "ec2:ModifyImageAttribute",
+                "ec2:DescribeImageAttribute",
                 "ec2:DescribeSnapshots",
                 "ec2:DescribeImportSnapshotTasks",
                 "ec2:DescribeImages",

--- a/notes/aws-iam-policies/prod-account/fcos-upload-amis
+++ b/notes/aws-iam-policies/prod-account/fcos-upload-amis
@@ -1,0 +1,37 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:ImportVolume",
+                "ec2:CreateTags",
+                "ec2:RegisterImage",
+                "ec2:CancelConversionTask",
+                "ec2:ImportSnapshot",
+                "ec2:CopyImage",
+                "ec2:ModifyImageAttribute",
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeImportSnapshotTasks",
+                "ec2:DescribeImages",
+                "ec2:DeleteVolume",
+                "ec2:ModifySnapshotAttribute",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeVolumes",
+                "ec2:CreateSnapshot",
+                "ec2:DescribeConversionTasks"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": [
+                "arn:aws:ec2:*::snapshot/*",
+                "arn:aws:ec2:*::image/*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
These files will help us track what permissions we have and allow us to methodically test and ask for changes to the policies to be made. 