### PR TITLE
metadata/release-index: add human-friendly specs

### DIFF
--- a/metadata/README.md
+++ b/metadata/README.md
@@ -39,10 +39,12 @@ This piece of metadata is meant to list all existing releases, on each stream.
 
  * URL: `https://builds.coreos.fedoraproject.org/prod/streams/${stream}/releases.json`
  * Usage: consumed by Cincinnati to discover valid releases
+ * [JSON document specifications][release-index-specs]
  * (TODO) release-index JSON schema
  * [release-index sample][release-index-sample]
 
 [release-index-sample]: ./release-index/sample.json
+[release-index-specs]: ./release-index/specifications.md
 
 ## Release metadata
 

--- a/metadata/release-index/specifications.md
+++ b/metadata/release-index/specifications.md
@@ -1,0 +1,14 @@
+# Release-index specifications
+
+The release-index is a JSON document with a single object containing the following fields:
+
+- `note` (optional, string): a human-friendly documentation text.
+- `stream` (mandatory, string): name of the release stream.
+- `metadata` (mandatory, object): metadata attributes for this JSON document.
+  - `last-modified` (mandatory, string): UTC timestamp for the last change, in ISO 8601 format.
+- `releases` (mandatory, list of objects): per-release details. Each entry MUST have a unique non-empty `version` field. The list MUST be sorted in ascending order, from oldest to latest release.
+  - `version` (mandatory, string): release version identifier.
+  - `metadata` (mandatory, string): URL to the release metadata document for this version.
+  - `commits` (mandatory, list of objects): per-architecture OSTree commits. Each entry MUST have a unique non-empty `architecture` field.
+    - `architecture` (mandatory, string): relevant base-architecture for this commit.
+    - `checksum` (mandatory, string): OSTree commit identifier.


### PR DESCRIPTION
This adds a human-friendly specification describing the semantics of
the release-index document.