### PR TITLE
instructions for requesting new packages

### DIFF
--- a/NEWPACKAGE.md
+++ b/NEWPACKAGE.md
@@ -1,0 +1,19 @@
+# Request to Include a New Package in Fedora CoreOS
+
+If you would like to propose the inclusion of a new package into the base
+content set of Fedora CoreOS, please open a [new issue](https://github.com/coreos/fedora-coreos-tracker/issues/new) 
+with the following questions answered.  The more detail provided for each
+question, the better informed everyone will be.
+
+Please title the new issue: `Package Request: <name of package>`
+
+1. What, if any, are the additional dependencies on the package? (i.e. does it pull in Python, Perl, etc)
+2. What is the size of the package and its dependencies?
+3. What problem are you trying to solve with this package? Or what functionality does the package provide?
+4. Can the software provided by the package be run from a container?  Explain why or why not.
+5. Can the tool(s) provided by the package be helpful in debugging container runtime issues?
+6. Can the tool(s) provided by the package be helpful in debugging networking issues?
+7. Is it possible to layer the package onto the base OS as a day 2 operation?  Explain why or why not.
+8. In the case of packages providing services and binaries, can the packaging be adjusted to just deliver binaries?
+9. Can the tool(s) provided by the package be used to do things we’d rather users not be able to do in FCOS? (e.g. can it be abused as a Turing complete interpreter?)
+10. Does the software provided by the package have a history of CVEs?

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ Fedora CoreOS is available for general use and no longer in preview.  We're
 continuing to add more platforms and functionality, fix bugs, and write
 documentation.  Please try out Fedora CoreOS and give us feedback!
 
+# Adding Packages to Fedora CoreOS
+
+We often find people asking for a particular package to be added to the base set of
+packages included in Fedora CoreOS. One of the goals of Fedora CoreOS is to
+remain as lean as possible, without impacting overall usability for our users.
+Thus, new package requests are carefully scrutinized to weigh the benefits and
+drawbacks of adding an additional package.
+
+If you would like to propose the inclusion of a new package in the base set of packages,
+please follow the instructions for [requesting a new package](NEWPACKAGE.md).
+
 # Releases
 
 See [RELEASES.md](RELEASES.md).


### PR DESCRIPTION
An initial set of instructions on how to request a new package be
added to FCOS. This can be folded into a chooser option for new
issues, if desired.

Closes #641