### PR TITLE
stream/rationale: several cleanups

### DIFF
--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -76,23 +76,6 @@ architectures:
               signature: https://artifacts.example.com/a9ytS8yB4cGZpca1.cpio.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
-          "installer.iso":
-            disk:
-              location: https://artifacts.example.com/KwKye6YW4SIIPrhY.iso
-              signature: https://artifacts.example.com/KwKye6YW4SIIPrhY.iso.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
-          installer-pxe:
-            kernel:
-              location: https://artifacts.example.com/EtqI0KsLIwZOHlCx
-              signature: https://artifacts.example.com/EtqI0KsLIwZOHlCx.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
-            initramfs:
-              location: https://artifacts.example.com/EhoS1x66RVA2k8y6.cpio.gz
-              signature: https://artifacts.example.com/EhoS1x66RVA2k8y6.cpio.gz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       openstack:
         release: 30.1.2.3
         formats:
@@ -118,15 +101,6 @@ architectures:
             disk:
               location: https://artifacts.example.com/Siejeeb6ohpu8Eel.qcow.xz
               signature: https://artifacts.example.com/Siejeeb6ohpu8Eel.qcow.xz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
-      virtualbox:
-        release: 30.1.2.3
-        formats:
-          ova:
-            disk:
-              location: https://artifacts.example.com/yohsh2haiquaeYah.ova
-              signature: https://artifacts.example.com/yohsh2haiquaeYah.ova.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       vmware:

--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -68,8 +68,12 @@ architectures:
               signature: https://artifacts.example.com/hkIj8FkCydT3lV9h.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             initramfs:
-              location: https://artifacts.example.com/a9ytS8yB4cGZpca1.cpio.gz
-              signature: https://artifacts.example.com/a9ytS8yB4cGZpca1.cpio.gz.sig
+              location: https://artifacts.example.com/a9ytS8yB4cGZpca1.img
+              signature: https://artifacts.example.com/a9ytS8yB4cGZpca1.img.sig
+              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            rootfs:
+              location: https://artifacts.example.com/Seb8em4QU9p6wEFr.img
+              signature: https://artifacts.example.com/Seb8em4QU9p6wEFr.img.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       openstack:
         release: 30.1.2.3

--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -35,10 +35,10 @@ architectures:
       digitalocean:
         release: 30.1.2.3
         formats:
-          "raw.xz":
+          "raw.gz":
             disk:
-              location: https://artifacts.example.com/ichaloomuHax9ahR.raw.xz
-              signature: https://artifacts.example.com/ichaloomuHax9ahR.raw.xz.sig
+              location: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz
+              signature: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       gcp:

--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -40,7 +40,6 @@ architectures:
               location: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz
               signature: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       gcp:
         release: 30.1.2.3
         formats:
@@ -49,7 +48,6 @@ architectures:
               location: https://artifacts.example.com/ais7tah1aa7Ahvei.tar.gz
               signature: https://artifacts.example.com/ais7tah1aa7Ahvei.tar.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       metal:
         release: 30.1.2.3
         formats:
@@ -64,18 +62,15 @@ architectures:
               location: https://artifacts.example.com/ADE5GO3bjAXeDcLO.iso
               signature: https://artifacts.example.com/ADE5GO3bjAXeDcLO.iso.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
           pxe:
             kernel:
               location: https://artifacts.example.com/hkIj8FkCydT3lV9h
               signature: https://artifacts.example.com/hkIj8FkCydT3lV9h.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
             initramfs:
               location: https://artifacts.example.com/a9ytS8yB4cGZpca1.cpio.gz
               signature: https://artifacts.example.com/a9ytS8yB4cGZpca1.cpio.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       openstack:
         release: 30.1.2.3
         formats:
@@ -111,7 +106,6 @@ architectures:
               location: https://artifacts.example.com/quohgh8ei0uzaD5a.ova
               signature: https://artifacts.example.com/quohgh8ei0uzaD5a.ova.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
 
     images:
       # Cloud images to be launched directly by users.  These are in a


### PR DESCRIPTION
This doesn't bring the rationale completely up to date with current reality (it's missing some platforms, and lists some cloud images we don't ship yet) but it's closer.