### PR TITLE
stream/rationale: more DigitalOcean fixes

### DIFF
--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -40,6 +40,7 @@ architectures:
               location: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz
               signature: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       gcp:
         release: 30.1.2.3
         formats:

--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -35,10 +35,10 @@ architectures:
       digitalocean:
         release: 30.1.2.3
         formats:
-          "raw.gz":
+          "qcow2.gz":
             disk:
-              location: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz
-              signature: https://artifacts.example.com/ichaloomuHax9ahR.raw.gz.sig
+              location: https://artifacts.example.com/ichaloomuHax9ahR.qcow2.gz
+              signature: https://artifacts.example.com/ichaloomuHax9ahR.qcow2.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       gcp:


### PR DESCRIPTION
The artifact format was wrong, and `uncompressed-sha256` is added by coreos/coreos-assembler#2144.