### PR TITLE
stream/rationale: re-add gcp uncompressed-sha256

### DIFF
--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -49,6 +49,7 @@ architectures:
               location: https://artifacts.example.com/ais7tah1aa7Ahvei.tar.gz
               signature: https://artifacts.example.com/ais7tah1aa7Ahvei.tar.gz.sig
               sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       metal:
         release: 30.1.2.3
         formats:


### PR DESCRIPTION
It's added by https://github.com/coreos/coreos-assembler/pull/2158.