### PR TITLE
templates: rebase: add back in steps for adding barrier releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -62,7 +62,7 @@ koji untag-build coreos-pool $untaglist
 ## Ship rebased `next`
 
 - [ ] Ship `next`
-- ~Set a new update barrier for N-2 on `next`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629).~  _(Skip for now, see https://github.com/coreos/fedora-coreos-tracker/issues/749#issuecomment-781449178)_
+- Set a new update barrier for N-2 on `next`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629).
 
 ## Update [fedora-coreos-config](https://github.com/coreos/fedora-coreos-config/) `testing-devel`
 
@@ -75,7 +75,7 @@ koji untag-build coreos-pool $untaglist
 ## Ship rebased `testing`
 
 - [ ] Ship `testing`
-- ~Set a new update barrier for N-2 on `testing`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/).~
+- Set a new update barrier for N-2 on `testing`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629).
 
 ## Disable `next-devel` stream
 
@@ -87,7 +87,7 @@ We prefer to disable `next-devel` when there is no difference between `testing-d
 ## Ship rebased `stable`
 
 - [ ] Ship `stable`
-- ~Set a new update barrier for N-2 on `stable`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/).~
+- Set a new update barrier for N-2 on `stable`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629).
 
 ## Miscellaneous container updates
 


### PR DESCRIPTION
We decided to continue to do this even though it's broken right now.
We have a plan to fix it in the future so let's leave the process in
place.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/749#issuecomment-848290710