### PR TITLE
internals/initramfs: update for coreos-ignition-setup-user

### DIFF
--- a/internals/README-initramfs.md
+++ b/internals/README-initramfs.md
@@ -55,7 +55,7 @@ In contrast for PXE the squashfs is in the `live-initramfs` directly.
 # /boot in the initramfs
 
 There are multiple services which access the `/boot` partition in the initramfs. They are (in running order):
-- `ignition-setup-user.service`: mounts `/boot` read-only to look for a user Ignition config. This is the first Ignition service to run (in parallel with the `-base` service).
+- `coreos-ignition-setup-user.service`: mounts `/boot` read-only to look for a user Ignition config. This is the first Ignition-related service to run.
 - `coreos-copy-firstboot-network.service`: mounts `/boot` read-only to look for NetworkManager keyfiles. This unit runs after Ignition's `ignition-fetch-offline.service` but before networking is optionally brought up as part of `dracut-initqueue.service`.
 - (on RHCOS) `rhcos-fips.service`: mounts `/boot` read-write to append `fips=1` to the BLS configs and reboot if FIPS mode is requested. This unit runs after `ignition-fetch.service` but before `ignition-disks.service`.
 - `coreos-boot-edit.service`: mounts `/boot` read-write late in the initramfs process after `ignition-files.service` to make final edits (e.g. remove firstboot networking configuration files if necessary, append rootmap kargs to the BLS configs).


### PR DESCRIPTION
`ignition-setup-base` is gone (Ignition handles it internally now) and `ignition-setup-user` has moved to fedora-coreos-config and renamed to `coreos-ignition-setup-user`.

xref https://github.com/coreos/fedora-coreos-config/pull/1095