### PR TITLE
Add missing line break in internal Markdown docs

### DIFF
--- a/internals/README-initramfs.md
+++ b/internals/README-initramfs.md
@@ -27,7 +27,7 @@ Note that Ignition and OSTree are both independent projects consumed by other di
 
 Ignition runs only on the first boot.  To account for this, ignition-dracut ships two targets:
 
-`ignition-complete.target`: Enabled on first boot
+`ignition-complete.target`: Enabled on first boot  
 `ignition-subsequent.target`: Enabled on every boot **except** the first
 
 `-complete` will pull in a lot of units, such as `ignition-fetch.service` and `ignition-disks.service`


### PR DESCRIPTION
I guess you've got the Markdown syntax "wrong" here and want a line break here. :slightly_smiling_face: