### PR TITLE
metadata/stream: add metadata.generator field

### DIFF
--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -4,6 +4,7 @@
 stream: stable
 metadata:
   last-modified: "2019-06-04T16:18:34Z"
+  generator: "fedora-coreos-stream-generator v0.1.0"
 architectures:
   x86_64:
     artifacts:

--- a/metadata/stream/sample.json
+++ b/metadata/stream/sample.json
@@ -1,7 +1,8 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-04-28T13:46:31Z"
+        "last-modified": "2021-04-28T13:46:31Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0"
     },
     "architectures": {
         "x86_64": {


### PR DESCRIPTION
It's useful to record the exact software version that generated an instance of stream metadata.