### PR TITLE
templates/rebase: disable `next-devel` using pipeline metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -81,8 +81,7 @@ koji untag-build coreos-pool $untaglist
 
 We prefer to disable `next-devel` when there is no difference between `testing-devel` and `next-devel`. This allows us to prevent wasting a bunch of resources (bandwidth, storage, compute) for no reason. After the switch to N if `next-devel` and `testing-devel` are in lockstep, then disable `next-devel`.
 
-- [ ] Remove `next-devel` from the list of "development streams" in [the pipeline](https://github.com/coreos/fedora-coreos-pipeline/blob/main/streams.groovy). [Example PR.](https://github.com/coreos/fedora-coreos-pipeline/pull/343)
-- [ ] Update the [promote-config job](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/promote-config.yml) to promote `next` from `testing-devel`. [Example PR.](https://github.com/coreos/fedora-coreos-streams/pull/322)
+- [ ] Follow the instructions [here](https://github.com/coreos/fedora-coreos-pipeline/tree/main/next-devel) to disable `next-devel`
 
 ## Ship rebased `stable`
 


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-pipeline/pull/451 adds a centralized mechanism for disabling the `next-devel` stream.  Use it during a rebase.