### PR TITLE
metadata/stream: add digest reference to KubeVirt image description

### DIFF
--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -155,9 +155,14 @@ architectures:
         # the best we can do.
         image: fedora-coreos-stable
       kubevirt:
-        release: 30.1.2.3
         # ContainerDisk in a container registry
-        image: exampleregistry.io/fcos/fcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773
+        # Ideally users use this pull spec, which specifies a floating tag.
+        # This value is expected to be stable over time.
+        image: exampleregistry.io/fcos/fcos:stable
+        # As an alternative, we also list a digest-based pull spec for the
+        # currently recommended image, and its release.
+        release: 30.1.2.3
+        digest-ref: exampleregistry.io/fcos/fcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773
       packet:
         # Images don't have addressable versions, so an operating system
         # slug is the best we can do.


### PR DESCRIPTION
In the current design, the KubeVirt image is presumed to be a pull spec with an image digest.  That implies that the user should reference the image by digest, when we'd prefer that they reference it by a stream-specific floating tag.

Define the existing `image` field to contain a pull spec with a floating tag for the stream.  We should still record the unique identifier of the current image (as we do for GCP images), so add a `digest-ref` field which always contains a fully-qualified pull spec with digest.

xref https://github.com/coreos/stream-metadata-go/pull/46

cc @rmohr @dustymabe 