### PR TITLE
Updated FCOS stream metadata sample/rationale/release

### DIFF
--- a/metadata/release/sample.json
+++ b/metadata/release/sample.json
@@ -4,6 +4,22 @@
   "architectures": {
     "x86_64": {
       "media": {
+        "aliyun": {
+          "artifacts": {
+            "qcow2.xz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-aliyun.qcow2.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-aliyun.qcow2.xz.sig",
+                "sha256": "8f1492f1e9e94ec3f3ecef188c4a2da52348c4b830f6365181bd03e1d969f161"
+              }
+            }
+          },
+          "images": {
+            "us-east-1": {
+              "image": "m-6wedcb2rfmhkcl2bsbz5"
+            }
+          }
+        },
         "aws": {
           "artifacts": {
             "vmdk.xz": {
@@ -20,13 +36,79 @@
             }
           }
         },
-        "qemu": {
+        "azure": {
+          "artifacts": {
+            "vhd.xz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-azure.vhd.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-azure.vhd.xz.sig",
+                "sha256": "4bb0e1595f66f344c1cc084e163c4352235b2accf3a1385b9eb4b3e4ca5b1d24"
+              }
+            }
+          }
+        },
+        "azurestack": {
+          "artifacts": {
+            "vhd.xz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-azurestack.vhd.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-azurestack.vhd.xz.sig",
+                "sha256": "344c1cc084e163c4352235b2accf34d24bb0e1595f66fa1385b9eb4b3e4ca5b1"
+              }
+            }
+          }
+        },
+        "digitalocean": {
+          "artifacts": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-digitalocean.qcow2.gz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-digitalocean.qcow2.gz.sig",
+                "sha256": "435224bb0e1595f344c1cc05b1d2484e163c66f35b2accf3a1385b9eb4b3e4ca"
+              }
+            }
+          }
+        },
+        "exoscale": {
           "artifacts": {
             "qcow2.xz": {
               "disk": {
-                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-qemu.qcow2.xz",
-                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-qemu.qcow2.xz.sig",
-                "sha256": "4dcc04bd43f48bc74a16bd7d20b47829591a2a2fbe3ee8d59fedef2b1ddd1264"
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-exoscale.qcow2.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-exoscale.qcow2.xz.sig",
+                "sha256": "435224bb0e1595f344c1cc05b1d2484e163c66f35b2accf3a1385b9eb4b3e4ca"
+              }
+            }
+          }
+        },
+        "gcp": {
+          "artifacts": {
+            "tar.gz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-gcp.tar.gz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-gcp.tar.gz.sig",
+                "sha256": "344c1cc05b1d2484e163c66f35b2accf3a1385b9eb435224bb0e1595f4b3e4ca"
+              }
+            }
+          }
+        },
+        "ibmcloud": {
+          "artifacts": {
+            "qcow2.xz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-ibmcloud.qcow2.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-ibmcloud.qcow2.xz.sig",
+                "sha256": "344c1cc05b1d2484e163c66f35b2accf3a1385b9eb435224bb0e1595f4b3e4ca"
+              }
+            }
+          }
+        },
+        "kubevirt": {
+          "artifacts": {
+            "qcow2.xz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-kubevirt.qcow2.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-kubevirt.qcow2.xz.sig",
+                "sha256": "2accf3a1385b9eb435224bb0e1595f4b3e4344c1cc05b1d2484e163c66f35bca"
               }
             }
           }
@@ -40,45 +122,39 @@
                 "sha256": "881178a4794816e623b02012a84b11d59a96dd59035508a0986a5b6c6be074ed"
               }
             },
-            "installer.iso": {
+            "iso": {
               "disk": {
-                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-installer.iso",
-                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-installer.iso.sig",
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live.iso",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live.iso.sig",
                 "sha256": "aab20fcafc240fa03f7e43370f8be8c14b99b045eca156a0f5e77286b2e9e8c4"
               }
             },
-            "installer-pxe": {
+            "pxe": {
               "kernel": {
-                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-installer-kernel",
-                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-installer-kernel.sig",
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live-kernel",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live-kernel.sig",
                 "sha256": "bb493370b3716a009628197b7fce41107f1f5349f1a7ef67a8ecc7eebb3d2183"
               },
               "initramfs": {
-                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-installer-initramfs.img",
-                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-installer-initramfs.img.sig",
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live-initramfs.img",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live-initramfs.img.sig",
                 "sha256": "04dde273b9e5d1b361beb44fde337f915509ad8e128fb408f793fdd0ae84c17d"
+              },
+              "rootfs": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live-rootfs.img",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-live-rootfs.img.sig",
+                "sha256": "509ad8e128fb408f793fdd0ae84c17d04dde273b9e5d1b361beb44fde337f915"
               }
             }
           }
         },
-        "azure": {
+        "nutanix": {
           "artifacts": {
-            "vhd.xz": {
+            "qcow2": {
               "disk": {
-                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-azure.vhd.xz",
-                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-azure.vhd.xz.sig",
-                "sha256": "4bb0e1595f66f344c1cc084e163c4352235b2accf3a1385b9eb4b3e4ca5b1d24"
-              }
-            }
-          }
-        },
-        "aliyun": {
-          "artifacts": {
-            "qcow2.xz": {
-              "disk": {
-                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-aliyun.qcow2.xz",
-                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-aliyun.qcow2.xz.sig",
-                "sha256": "8f1492f1e9e94ec3f3ecef188c4a2da52348c4b830f6365181bd03e1d969f161"
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-nutanix.qcow2",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-nutanix.qcow2.sig",
+                "sha256": "1b3e4ca5b1d2463c4352235b2accf95f66f344c1cc084e3a1385b9eb4bb0e154"
               }
             }
           }
@@ -94,6 +170,28 @@
             }
           }
         },
+        "qemu": {
+          "artifacts": {
+            "qcow2.xz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-qemu.qcow2.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-qemu.qcow2.xz.sig",
+                "sha256": "4dcc04bd43f48bc74a16bd7d20b47829591a2a2fbe3ee8d59fedef2b1ddd1264"
+              }
+            }
+          }
+        },
+        "virtualbox": {
+          "artifacts": {
+            "ova": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-virtualbox.ova",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-virtualbox.ova.sig",
+                "sha256": "54729f458c1552c19aa2f2b905860fadbe0a714df45d1d49731725038895094c"
+              }
+            }
+          }
+        },
         "vmware": {
           "artifacts": {
             "ova": {
@@ -101,6 +199,17 @@
                 "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-vmware.ova",
                 "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-vmware.ova.sig",
                 "sha256": "b905860fadbe0a754729f458c1552c19aa2f214df45d1d49731725038895094c"
+              }
+            }
+          }
+        },
+        "vultr": {
+          "artifacts": {
+            "raw.xz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-vultr.raw.xz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-vultr.raw.xz.sig",
+                "sha256": "d7d20b47829591a2a2fbe3ee8d59fe4dcc04bd43f48bc74a16bdef2b1ddd1264"
               }
             }
           }

--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -12,6 +12,15 @@ architectures:
       # openstack. Some will likely only be useful for cloud operators,
       # such as digitalocean or packet.  Some, such as aws, are useful
       # for users in special situations.
+      aliyun:
+        release: 30.1.2.3
+        formats:
+          "qcow2.xz":
+            disk:
+              location: https://artifacts.example.com/g0xah6aenvaaVosh.qcow2.xz
+              signature: https://artifacts.example.com/g0xah6aenvaaVosh.qcow2.xz.sig
+              sha256: 149afbf4c8996fb92427ae3b0c44298fc1ce41e4649b934ca495991b7852b855
+              uncompressed-sha256: d02d5ac0f2a2789602e9df950c38acb15380d2799b4bdb59394e4eeabdd3a662
       aws:
         release: 30.1.2.3
         formats:
@@ -27,11 +36,20 @@ architectures:
       azure:
         release: 30.1.2.3
         formats:
-          "vdi.xz":
+          "vhd.xz":
             disk:
-              location: https://artifacts.example.com/aeng0xah6vaaVosh.vdi.xz
-              signature: https://artifacts.example.com/aeng0xah6vaaVosh.vdi.xz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              location: https://artifacts.example.com/6vaaVoshaeng0xah.vhd.xz
+              signature: https://artifacts.example.com/6vaaVoshaeng0xah.vhd.xz.sig
+              sha256: f4c8996fb92427ae41e4e3b0c44298fc1c149afb649b934ca495991b7852b855
+              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
+      azurestack:
+        release: 30.1.2.3
+        formats:
+          "vhd.xz":
+            disk:
+              location: https://artifacts.example.com/ng0xahos6aevaaVh.vhd.xz
+              signature: https://artifacts.example.com/ng0xahos6aevaaVh.vhd.xz.sig
+              sha256: ae41e4649b934ca495991b7852b855e3b0c44298fc1c149afbf4c8996fb92427
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       digitalocean:
         release: 30.1.2.3
@@ -40,8 +58,17 @@ architectures:
             disk:
               location: https://artifacts.example.com/ichaloomuHax9ahR.qcow2.gz
               signature: https://artifacts.example.com/ichaloomuHax9ahR.qcow2.gz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: 427ae41e4649b934ca495991b7852b855e3b0c44298fc1c149afbf4c8996fb92
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
+      exoscale:
+        release: 30.1.2.3
+        formats:
+          "qcow2.xz":
+            disk:
+              location: https://artifacts.example.com/aeng0xah6vaaVosh.qcow2.xz
+              signature: https://artifacts.example.com/aeng0xah6vaaVosh.qcow2.xz.sig
+              sha256: 49afbf4c8996fb92427ae41e464e3b0c44298fc1c19b934ca495991b7852b855
+              uncompressed-sha256: f2a2789602e9df950c380d2738acb15d02d5ac099b4bdb59394e4eeabdd3a662
       gcp:
         release: 30.1.2.3
         formats:
@@ -49,7 +76,25 @@ architectures:
             disk:
               location: https://artifacts.example.com/ais7tah1aa7Ahvei.tar.gz
               signature: https://artifacts.example.com/ais7tah1aa7Ahvei.tar.gz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: 96fb92427ae41e4649b934ca495991b7852b85e3b0c44298fc1c149afbf4c895
+              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
+      ibmcloud:
+        release: 30.1.2.3
+        formats:
+          "qcow2.xz":
+            disk:
+              location: https://artifacts.example.com/0xah6vaaenVoshga.qcow2.xz
+              signature: https://artifacts.example.com/0xah6vaaenVoshga.qcow2.xz.sig
+              sha256: ae3b0c44298fc1ce41e4649b149afbf4c8996fb92427934ca495991b7852b855
+              uncompressed-sha256: 02e9df950c38acb1538d02d5ac0f2a278960d2799b4bdb59394e4eeabdd3a662
+      kubevirt:
+        release: 30.1.2.3
+        formats:
+          "qcow2.xz":
+            disk:
+              location: https://artifacts.example.com/Kiejeeb6ohpu8Eel.qcow2.xz
+              signature: https://artifacts.example.com/Kiejeeb6ohpu8Eel.qcow2.xz.sig
+              sha256: 2427ae41e4649b934ca495991b7852b85e3b0c44298fc1c149afbf4c8996fb95
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       metal:
         release: 30.1.2.3
@@ -58,43 +103,42 @@ architectures:
             disk:
               location: https://artifacts.example.com/xTqYJZKCPNvoNs6B.raw.xz
               signature: https://artifacts.example.com/xTqYJZKCPNvoNs6B.raw.xz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: 6fb92427ae41e4649b934ca49e3b0c44298fc1c149afbf4c8995991b7852b855
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
           iso:
             disk:
               location: https://artifacts.example.com/ADE5GO3bjAXeDcLO.iso
               signature: https://artifacts.example.com/ADE5GO3bjAXeDcLO.iso.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: 8996fb92427ae41e4649b934ca495991b78e3b0c44298fc1c149afbf4c52b855
           pxe:
             kernel:
               location: https://artifacts.example.com/hkIj8FkCydT3lV9h
               signature: https://artifacts.example.com/hkIj8FkCydT3lV9h.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: 27ae41e4649b934ca495991b7852be3b0c44298fc1c149afbf4c8996fb924855
             initramfs:
               location: https://artifacts.example.com/a9ytS8yB4cGZpca1.img
               signature: https://artifacts.example.com/a9ytS8yB4cGZpca1.img.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: ae41e4649b934ca495991b7852be3b0c44298fc1c149afbf4c8996fb92427855
             rootfs:
               location: https://artifacts.example.com/Seb8em4QU9p6wEFr.img
               signature: https://artifacts.example.com/Seb8em4QU9p6wEFr.img.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: fb92427ae41e4649b93e3b0c44298fc1c149afbf4c89964ca495991b7852b855
+      nutanix:
+        release: 30.1.2.3
+        formats:
+          "qcow2":
+            disk:
+              location: https://artifacts.example.com/xah6vaaVaeng0osh.qcow2
+              signature: https://artifacts.example.com/xah6vaaVaeng0osh.qcow2.sig
+              sha256: 991b7852b85b0c44298fc1c149afbfe36fb92427ae41e4649b934ca4954c8995
       openstack:
         release: 30.1.2.3
         formats:
-          "qcow.xz":
+          "qcow2.xz":
             disk:
-              location: https://artifacts.example.com/oKooheogobofai8l.qcow.xz
-              signature: https://artifacts.example.com/oKooheogobofai8l.qcow.xz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-              uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
-      kubevirt:
-        release: 30.1.2.3
-        formats:
-          "qcow.xz":
-            disk:
-              location: https://artifacts.example.com/Kiejeeb6ohpu8Eel.qcow.xz
-              signature: https://artifacts.example.com/Kiejeeb6ohpu8Eel.qcow.xz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              location: https://artifacts.example.com/oKooheogobofai8l.qcow2.xz
+              signature: https://artifacts.example.com/oKooheogobofai8l.qcow2.xz.sig
+              sha256: ae41e4649b934ca495991b785e3b0c44298fc1c149afbf4c8996fb924272b855
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       packet:
         release: 30.1.2.3
@@ -103,17 +147,25 @@ architectures:
             disk:
               location: https://artifacts.example.com/Oofohng0xo2phai5.raw.xz
               signature: https://artifacts.example.com/Oofohng0xo2phai5.raw.xz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: e41e4649b934ca495991b7852b85e3b0c44298fc1c149afbf4c8996fb92427a5
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
       qemu:
         release: 30.1.2.3
         formats:
-          "qcow.xz":
+          "qcow2.xz":
             disk:
-              location: https://artifacts.example.com/Siejeeb6ohpu8Eel.qcow.xz
-              signature: https://artifacts.example.com/Siejeeb6ohpu8Eel.qcow.xz.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              location: https://artifacts.example.com/Siejeeb6ohpu8Eel.qcow2.xz
+              signature: https://artifacts.example.com/Siejeeb6ohpu8Eel.qcow2.xz.sig
+              sha256: b0c44298fc1c149afbf4c8996fb9242e37ae41e4649991b7852b855b934ca495
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
+      virtualbox:
+        release: 30.1.2.3
+        formats:
+          ova:
+            disk:
+              location: https://artifacts.example.com/quohgh8ei0uzaD5a.ova
+              signature: https://artifacts.example.com/quohgh8ei0uzaD5a.ova.sig
+              sha256: 4c8996fb92427ae41e4649b934ca4e3b0c44298fc1c149afbf95991b7852b855
       vmware:
         release: 30.1.2.3
         formats:
@@ -121,12 +173,29 @@ architectures:
             disk:
               location: https://artifacts.example.com/quohgh8ei0uzaD5a.ova
               signature: https://artifacts.example.com/quohgh8ei0uzaD5a.ova.sig
-              sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+              sha256: 96fb92427ae41e4649b934cae3b0c44298fc1c149afbf4c89495991b7852b855
+      vultr:
+        release: 30.1.2.3
+        formats:
+          "raw.xz":
+            disk:
+              location: https://artifacts.example.com/ah6vaaVaeng0xosh.raw.xz
+              signature: https://artifacts.example.com/ah6vaaVaeng0xosh.raw.xz.sig
+              sha256: ae3b0c44298fc1ce41e4649b149afbf4c8996fb92427934ca495991b7852b855
+              uncompressed-sha256: 02e9df950c38acb1538d02d5ac0f2a278960d2799b4bdb59394e4eeabdd3a662
 
     images:
       # Cloud images to be launched directly by users.  These are in a
       # separate section because they might not always in sync with the
       # release artifacts above.
+      aliyun:
+        regions:
+          ap-northeast-1:
+            release: 30.1.2.3
+            image: m-cb2rfmhkcl2b6wedsbz5
+          ap-south-1:
+            release: 30.1.2.3
+            image: m-ef3e19la2d35aftwxz5p
       aws:
         regions:
           us-east-1:
@@ -141,6 +210,12 @@ architectures:
         # string, and represents advice rather than a value we might
         # change.
         image: Fedora:CoreOS:stable:latest
+      digitalocean:
+        # We don't control platform ingest, so an image slug is probably
+        # the best we can do.
+        image: fedora-coreos-stable
+      exoscale:
+        image: Linux Fedora CoreOS 64-bit
       gcp:
         # Ideally users use the project + family.  These are static strings,
         # and represent advice rather than a value we might change.
@@ -150,10 +225,6 @@ architectures:
         # and its release.
         release: 30.1.2.3
         name: fedora-coreos-30-1-2-3-gcp-x86-64
-      digitalocean:
-        # We don't control platform ingest, so an image slug is probably
-        # the best we can do.
-        image: fedora-coreos-stable
       kubevirt:
         # ContainerDisk in a container registry
         # Ideally users use this pull spec, which specifies a floating tag.

--- a/metadata/stream/sample.json
+++ b/metadata/stream/sample.json
@@ -46,6 +46,19 @@
                         }
                     }
                 },
+                "azurestack": {
+                    "release": "33.20210412.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3bd5baf21335ada861b5e01e8628ba40bc04050a436b9eaa0504ba6c33626a05",
+                                "uncompressed-sha256": "de9d7a5b1f0f69746a807148e1dbf64aa2593ac3d4e152fbb4f657da170dcece"
+                            }
+                        }
+                    }
+                },
                 "digitalocean": {
                     "release": "33.20210412.3.0",
                     "formats": {
@@ -96,6 +109,19 @@
                         }
                     }
                 },
+                "kubevirt": {
+                    "release": "33.20210412.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-kubevirt.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-kubevirt.x86_64.qcow2.xz.sig",
+                                "sha256": "6343b99ca70975bd821050f274aa1db0898fb88aae95a79f63d18a2e2a489e26",
+                                "uncompressed-sha256": "744f25cf86927fe4780b57cd75c2d5b979e15336e4c9bd02fe4f71827d820d4c"
+                            }
+                        }
+                    }
+                },
                 "metal": {
                     "release": "33.20210412.3.0",
                     "formats": {
@@ -141,6 +167,18 @@
                         }
                     }
                 },
+                "nutanix": {
+                    "release": "33.20210412.3.0",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "650bb496c94c3fc815126daaa6beb2270ae870cb036df5b43c348da00e788dab" 
+                            }
+                        }
+                    }
+                },     
                 "openstack": {
                     "release": "33.20210412.3.0",
                     "formats": {
@@ -163,6 +201,18 @@
                                 "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-qemu.x86_64.qcow2.xz.sig",
                                 "sha256": "8dce159f743c777fe9c429648e8a16928b55d0c1bc8e599a82ba71870fdc5e5a",
                                 "uncompressed-sha256": "a21be448bb0ceee7a373cae232c4cadd979c3db844521d3c10888e42c405c684"
+                            }
+                        }
+                    }
+                },
+                "virtualbox": {
+                    "release": "33.20210412.3.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a54f52901817165c74b9d265d8ccf0a6c622006e2a13444fc1145970b8c9135d"
                             }
                         }
                     }


### PR DESCRIPTION
To have a complete representation of the artifacts we support in the
stream metadata sample,rationale & release, the FCOS stream metadata sample/
rationale/release have been updated with the missing platforms.

Resolves : https://issues.redhat.com/browse/COS-1364