### PR TITLE
templates: format bug-report Ignition config as YAML

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -57,7 +57,10 @@ body:
     id: bug-ignition
     attributes:
       label: Ignition config
-      description: The Butane config or Ignition config used to provision your system. Be sure to sanitize any private data. If not using Butane to generate your Ignition config, does the Ignition config pass validation using [ignition-validate](https://coreos.github.io/ignition/getting-started/#config-validation)?
+      description: The Butane config or Ignition config used to provision your system. Be sure to sanitize any private data. If not using Butane to generate your Ignition config, ensure the Ignition config passes validation using [ignition-validate](https://coreos.github.io/ignition/getting-started/#config-validation).
+      # Might be Butane YAML or Ignition JSON, which is upward-compatible
+      # with YAML
+      render: yaml
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -54,9 +54,9 @@ body:
       required: true
 
   - type: textarea
-    id: bug-ignition
+    id: bug-config
     attributes:
-      label: Ignition config
+      label: Butane or Ignition config
       description: The Butane config or Ignition config used to provision your system. Be sure to sanitize any private data. If not using Butane to generate your Ignition config, ensure the Ignition config passes validation using [ignition-validate](https://coreos.github.io/ignition/getting-started/#config-validation).
       # Might be Butane YAML or Ignition JSON, which is upward-compatible
       # with YAML


### PR DESCRIPTION
Users often post Butane configs rather than Ignition configs, and JSON is upward-compatible with YAML, so cover our bases by calling it YAML. This prevents the user from having to manually add a code block.  Explicitly label the field as "Butane or Ignition config".