### PR TITLE
Add Hyper-V metadata

### DIFF
--- a/metadata/release/sample.json
+++ b/metadata/release/sample.json
@@ -91,6 +91,17 @@
             }
           }
         },
+        "hyperv": {
+          "artifacts": {
+            "vhdx.zip": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-hyperv.vhdx.zip",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-hyperv.vhdx.zip.sig",
+                "sha256": "a889159d661339e635372b807f0a98bb93c64aabfaf89a801b2f03491488f0ef"
+              }
+            }
+          }
+        },
         "ibmcloud": {
           "artifacts": {
             "qcow2.xz": {

--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -78,6 +78,14 @@ architectures:
               signature: https://artifacts.example.com/ais7tah1aa7Ahvei.tar.gz.sig
               sha256: 96fb92427ae41e4649b934ca495991b7852b85e3b0c44298fc1c149afbf4c895
               uncompressed-sha256: 38acb15d02d5ac0f2a2789602e9df950c380d2799b4bdb59394e4eeabdd3a662
+      hyperv:
+        release: 30.1.2.3
+        formats:
+          "vhdx.zip":
+            disk:
+              location: https://artifacts.example.com/quohgh8ei0uzaD5a.vhdx.zip
+              signature: https://artifacts.example.com/quohgh8ei0uzaD5a.vhdx.zip.sig
+              sha256: 4c8996fb92427ae41e4649b934ca4e3b0c44298fc1c149afbf95991b7852b855
       ibmcloud:
         release: 30.1.2.3
         formats:

--- a/metadata/stream/sample.json
+++ b/metadata/stream/sample.json
@@ -96,6 +96,18 @@
                         }
                     }
                 },
+                "hyperv": {
+                    "release": "33.20210412.3.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "728e876d87ec71de27fc1d882840e6877346423433339a2b8606fa28e57413fd"
+                            }
+                        }
+                    }
+                },
                 "ibmcloud": {
                     "release": "33.20210412.3.0",
                     "formats": {


### PR DESCRIPTION
Add example metadata for new platform support of hyperv. This supports:

  * https://github.com/coreos/fedora-coreos-tracker/issues/1411
  * https://github.com/coreos/fedora-coreos-tracker/issues/1424