### PR TITLE
templates/rebase: move one section; delete another

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -85,10 +85,6 @@ Branching is when a new stream is "branched" off of `rawhide`. This eventually b
 - [ ] Ship `testing`
 - [ ] Set a new update barrier for the final release of N-1 on `testing`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-1247314065)
 
-### Disable `branched` stream
-
-- [ ] Update [streams.groovy](https://github.com/coreos/fedora-coreos-pipeline/blob/main/streams.groovy) to remove the `branched` stream in the list of mechanical refs.
-
 ### Untag old packages
 
 `koji untag` N-2 packages from the pool (at some point we'll have GC in place to do this for us, but for now we must remember to do this manually or otherwise distRepo will fail once the signed packages are GC'ed). For example the following snippet finds all RPMs signed by the Fedora 32 key and untags them. Use this process:

--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -85,6 +85,24 @@ Branching is when a new stream is "branched" off of `rawhide`. This eventually b
 - [ ] Ship `testing`
 - [ ] Set a new update barrier for the final release of N-1 on `testing`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-1247314065)
 
+### Disable `next-devel` stream
+
+We prefer to disable `next-devel` when there is no difference between `testing-devel` and `next-devel`. This allows us to prevent wasting a bunch of resources (bandwidth, storage, compute) for no reason. After the switch to N if `next-devel` and `testing-devel` are in lockstep, then disable `next-devel`.
+
+- [ ] Follow the instructions [here](https://github.com/coreos/fedora-coreos-pipeline/tree/main/next-devel) to disable `next-devel`
+
+### Switch upstream packages to shipping release binaries from Fedora (N)
+
+- [ ] Update [repo-templates](https://github.com/coreos/repo-templates) [config.yaml](https://github.com/coreos/repo-templates/blob/main/config.yaml) with the version number and GPG key ID for Fedora (N).
+
+
+## After Fedora (N) GA
+
+### Ship rebased `stable`
+
+- [ ] Ship `stable`
+- [ ] Set a new update barrier for the final release of N-1 on `stable`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-1247314065)
+
 ### Untag old packages
 
 `koji untag` N-2 packages from the pool (at some point we'll have GC in place to do this for us, but for now we must remember to do this manually or otherwise distRepo will fail once the signed packages are GC'ed). For example the following snippet finds all RPMs signed by the Fedora 32 key and untags them. Use this process:
@@ -141,25 +159,6 @@ cat untaglist | xargs -L50 koji untag-build coreos-pool
 - [ ] Remove the N-2 signing key from the tag info for the coreos-pool tag. The following commands view the current settings and then update the list to the 33/34/35 keys. You'll most likely have to get someone from releng to run the second command (`edit-tag`).
     - `koji taginfo coreos-pool`
     - `koji edit-tag coreos-pool -x tag2distrepo.keys="9570ff31 45719a39 9867c58f"`
-
-
-### Disable `next-devel` stream
-
-We prefer to disable `next-devel` when there is no difference between `testing-devel` and `next-devel`. This allows us to prevent wasting a bunch of resources (bandwidth, storage, compute) for no reason. After the switch to N if `next-devel` and `testing-devel` are in lockstep, then disable `next-devel`.
-
-- [ ] Follow the instructions [here](https://github.com/coreos/fedora-coreos-pipeline/tree/main/next-devel) to disable `next-devel`
-
-### Switch upstream packages to shipping release binaries from Fedora (N)
-
-- [ ] Update [repo-templates](https://github.com/coreos/repo-templates) [config.yaml](https://github.com/coreos/repo-templates/blob/main/config.yaml) with the version number and GPG key ID for Fedora (N).
-
-
-## After Fedora (N) GA
-
-### Ship rebased `stable`
-
-- [ ] Ship `stable`
-- [ ] Set a new update barrier for the final release of N-1 on `stable`. In the barrier entry set a link to [the docs](https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/). See [discussion](https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-1247314065)
 
 ### Open ticket for the next Fedora rebase
 


### PR DESCRIPTION
```
commit de41d0db47e2d0a420f9dbcc5d837181f9415716
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed May 3 14:56:54 2023 -0400

    templates/rebase: move "Untag old packages" section later
    
    This doesn't need to happen until the end which is usually the best
    place for cleanups anyway. Let's move it later.

commit 5bea275219350a12c0269eb72b02b299fa3724ee
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed May 3 14:39:45 2023 -0400

    templates/rebase: Remove 'Disable `branched` stream' section
    
    This should have been removed in fd62a94 when a step for this was added
    to another section.
```
