### PR TITLE
templates/rebase: more updates from recent experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -132,20 +132,9 @@ podman run -it --rm quay.io/fedora/fedora-coreos:testing-devel rpm -qai | grep -
 podman rmi quay.io/fedora/fedora-coreos:testing-devel
 ```
 
-If there are any RPMs signed by the old key they'll need to be investigated. Maybe they shouldn't be used any longer. Or maybe they're still needed.
+If there are any RPMs signed by the old key they'll need to be investigated. Maybe they shouldn't be used any longer. Or maybe they're still needed. One example of this is the shim RPM where the same build could be used for many Fedora releases. In this case you'll need to untag the RPM from `coreos-pool`, run a `koji distrepo`, which will remove that RPM from the repo metadata, and then re-tag it into the pool. The RPM in the repo will now be signed with a newer signing key.
 
-- [ ] For any RPMS still used by `N-1` based FCOS let's remove them from the untaglist. Check by running:
 
-```
-f32key=12c944d0
-key=$f32key
-podman run -it --rm quay.io/fedora/fedora-coreos:stable rpm -qai | grep -B 9 $key
-podman rmi quay.io/fedora/fedora-coreos:stable
-```
-
-NOTE: This assumes `stable` is still on `N-1`.
-
-Remove any entries from the `untaglist` file that are still being used.
 
 - [ ] After verifying the list looks good, untag:
 

--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -140,7 +140,7 @@ If there are any RPMs signed by the old key they'll need to be investigated. May
 
 ```
 # use xargs so we don't exhaust bash string limit
-cat untaglist | xargs -L50 koji untag-build coreos-pool
+cat untaglist | xargs -L50 koji untag-build -v coreos-pool
 ```
 
 - [ ] Now that untagging is done, give a heads up to rpm-ostree developers that N-2 packages have been untagged and that they may need to update their CI compose tests to freeze on a newer FCOS commit.

--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -169,6 +169,9 @@ These are various containers in use throughout our ecosystem. We should update o
     - [Dockerfile](https://github.com/coreos/butane/blob/main/Dockerfile)
 - [ ] Update fedora-coreos-cincinnati
     - [Dockerfile](https://github.com/coreos/fedora-coreos-cincinnati/blob/main/dist/fedora-infra/Dockerfile)
+    - [ImageStream](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/coreos-cincinnati/templates/imagestream.yml)
+    - [BuildConfig](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/coreos-cincinnati/templates/buildconfig.yml)
+    - [Git Hash Variables (Optional)](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/coreos-cincinnati/vars)
 - [ ] Update config-bot
     - [Dockerfile](https://github.com/coreos/fedora-coreos-releng-automation/blob/main/config-bot/Dockerfile)
 - [ ] Update coreos-koji-tagger
@@ -179,3 +182,7 @@ These are various containers in use throughout our ecosystem. We should update o
     - [Dockerfile](https://github.com/coreos/fedora-coreos-releng-automation/blob/main/coreos-ostree-importer/Dockerfile)
     - [ImageStream](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/coreos-ostree-importer/templates/imagestream.yml)
     - [BuildConfig](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/coreos-ostree-importer/templates/buildconfig.yml)
+- [ ] Update fedora-ostree-pruner
+    - [Dockerfile](https://github.com/coreos/fedora-coreos-releng-automation/blob/main/fedora-ostree-pruner/Dockerfile)
+    - [ImageStream](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/fedora-ostree-pruner/templates/imagestream.yml)
+    - [BuildConfig](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/fedora-ostree-pruner/templates/buildconfig.yml)


### PR DESCRIPTION
```
commit 46fcf448dc2ec5ce9a4969b71b3106f2e878fd73
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon May 22 10:16:52 2023 -0400

    templates/rebase: additional container update steps
    
    - We refactored coreos-cincinnati a bit to look more like the other Apps
      so let's add steps here for updating it.
    - Add fedora-ostree-pruner to the list since that's now running in
      production too.

commit d7b51ed1c42cd2d5c9aacfafaeffc11e01b01725
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon May 22 10:15:58 2023 -0400

    templates/rebase: add -v to `koji untag-build`
    
    This will give you some status updates to the screen while it's running.
    Otherwise there's not much feedback to the user and you aren't sure if
    it's working or not.

commit a6a9654769e5ce96ce551d647378ae81552d9853
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon May 22 10:14:56 2023 -0400

    templates/rebase: drop some tagging steps; add comments for clarity
    
    I found some of these steps unnecessary, but also needed more context
    for one problem I ran into during this cycle so I added it here.
```
