### PR TITLE
Update FCOS stream metadata for Apple Hypervisor

### DIFF
--- a/metadata/release/sample.json
+++ b/metadata/release/sample.json
@@ -36,6 +36,17 @@
             }
           }
         },
+        "applehv": {
+          "artifacts": {
+            "raw.gz": {
+              "disk": {
+                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-applehv.raw.gz",
+                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/30.20190801.0/x86_64/fedora-coreos-30.20190801.0-applehv.raw.gz.sig",
+                "sha256": "a889159d661339e635372b807f0a98bb93c64aabfaf89a801b2f03491488f0ef"
+              }
+            }
+          }
+        },
         "azure": {
           "artifacts": {
             "vhd.xz": {

--- a/metadata/stream/rationale.yaml
+++ b/metadata/stream/rationale.yaml
@@ -21,6 +21,14 @@ architectures:
               signature: https://artifacts.example.com/g0xah6aenvaaVosh.qcow2.xz.sig
               sha256: 149afbf4c8996fb92427ae3b0c44298fc1ce41e4649b934ca495991b7852b855
               uncompressed-sha256: d02d5ac0f2a2789602e9df950c38acb15380d2799b4bdb59394e4eeabdd3a662
+      applehv:
+        release: 30.1.2.3
+        formats:
+          "raw.gz":
+            disk:
+              location: https://artifacts.example.com/quohgh8ei0uzaD5a.raw.gz
+              signature: https://artifacts.example.com/quohgh8ei0uzaD5a.raw.gz.sig
+              sha256: 4c8996fb92427ae41e4649b934ca4e3b0c44298fc1c149afbf95991b7852b855
       aws:
         release: 30.1.2.3
         formats:

--- a/metadata/stream/sample.json
+++ b/metadata/stream/sample.json
@@ -20,6 +20,18 @@
                         }
                     }
                 },
+                "applehv": {
+                    "release": "33.20210412.3.0",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-hyperv.x86_64.raw.gz.sig",
+                                "sha256": "728e876d87ec71de27fc1d882840e6877346423433339a2b8606fa28e57413fd"
+                            }
+                        }
+                    }
+                },
                 "aws": {
                     "release": "33.20210412.3.0",
                     "formats": {


### PR DESCRIPTION
Add new platform (applehv) for the Apple Hypervisor which uses the raw disk format.

See coreos/fedora-coreos-tracker#1533 and coreos/fedora-coreos-tracker#1548