### PR TITLE
Only mention Matrix channel as chat room

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ technologies and produce Fedora CoreOS.
 
 - Main mailing list: [coreos@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/)
 - Status mailing list: [coreos-status@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/) (announcements/important messages)
-- Chat room: [`#coreos:fedoraproject.org` on Matrix](https://matrix.to/#/#coreos:fedoraproject.org)
+- Chat room: [`#coreos:fedoraproject.org` on Matrix](https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org)
   - Note that meetings still happen on IRC for now (see below).
 - Forum at [https://discussion.fedoraproject.org/tag/coreos](https://discussion.fedoraproject.org/tag/coreos)
 - Feature planning and important issue tracking at [github.com/coreos/fedora-coreos-tracker](https://github.com/coreos/fedora-coreos-tracker)

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ technologies and produce Fedora CoreOS.
 
 # Communication channels for Fedora CoreOS
 
-- main mailing list: [coreos@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/)
-- status mailing list: [coreos-status@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/) (announcements/important messages)
+- Main mailing list: [coreos@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/)
+- Status mailing list: [coreos-status@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/) (announcements/important messages)
 - Chat room: [`#coreos:fedoraproject.org` on Matrix](https://matrix.to/#/#coreos:fedoraproject.org)
   - Note that meetings still happen on IRC for now (see below).
-- forum at [https://discussion.fedoraproject.org/tag/coreos](https://discussion.fedoraproject.org/tag/coreos)
-- feature planning and important issue tracking at [github.com/coreos/fedora-coreos-tracker](https://github.com/coreos/fedora-coreos-tracker)
-- website at [https://getfedora.org/coreos/](https://getfedora.org/coreos/)
-- documentation at [https://docs.fedoraproject.org/en-US/fedora-coreos/](https://docs.fedoraproject.org/en-US/fedora-coreos/)
+- Forum at [https://discussion.fedoraproject.org/tag/coreos](https://discussion.fedoraproject.org/tag/coreos)
+- Feature planning and important issue tracking at [github.com/coreos/fedora-coreos-tracker](https://github.com/coreos/fedora-coreos-tracker)
+- Website at [https://getfedora.org/coreos/](https://getfedora.org/coreos/)
+- Documentation at [https://docs.fedoraproject.org/en-US/fedora-coreos/](https://docs.fedoraproject.org/en-US/fedora-coreos/)
 - Twitter: [@fedoracoreos](https://twitter.com/fedoracoreos)
 
 # Roadmap/Plans

--- a/README.md
+++ b/README.md
@@ -27,15 +27,8 @@ technologies and produce Fedora CoreOS.
 
 - main mailing list: [coreos@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/)
 - status mailing list: [coreos-status@lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/) (announcements/important messages)
-- Chat rooms:
-  - Matrix: [`#coreos:fedoraproject.org` on Matrix](https://matrix.to/#/#coreos:fedoraproject.org)
-  - IRC: [`#fedora-coreos` on Libera.Chat](https://web.libera.chat/#fedora-coreos) (ircs://irc.libera.chat:6697/#fedora-coreos)
-  - As of 2023-08-06 14UTC, the two rooms are not bridged together anymore thus
-    writing a message to IRC will not reach Matrix users (and vice versa). Note
-    that a lot of CoreOS developers have moved to Matrix thus the IRC channel
-    is likely to get less attention and we recommend joining via Matrix. See
-    [Matrix to libera.chat (IRC) bridge unavailable](https://communityblog.fedoraproject.org/matrix-to-libera-chat-irc-bridge-unavailable/).
-    The meetings still happen on IRC for now.
+- Chat room: [`#coreos:fedoraproject.org` on Matrix](https://matrix.to/#/#coreos:fedoraproject.org)
+  - Note that meetings still happen on IRC for now (see below).
 - forum at [https://discussion.fedoraproject.org/tag/coreos](https://discussion.fedoraproject.org/tag/coreos)
 - feature planning and important issue tracking at [github.com/coreos/fedora-coreos-tracker](https://github.com/coreos/fedora-coreos-tracker)
 - website at [https://getfedora.org/coreos/](https://getfedora.org/coreos/)

--- a/docs/ci-and-builds.md
+++ b/docs/ci-and-builds.md
@@ -51,7 +51,7 @@ Examples:
 
 ## quay.io/coreos-assembler namespace
 
-A key aspect of Fedora CoreOS as well as RHEL CoreOS is [coreos-assembler](https://github.com/coreos/coreos-assembler).  As of today, we build it in quay.io and deliver it that way in the `quay.io/coreos-assembler` namespace.  The list of administrators for this namespace is managed independently of anything else.  If you think you need administrator access, file a ticket or ask on #fedora-coreos IRC.
+A key aspect of Fedora CoreOS as well as RHEL CoreOS is [coreos-assembler](https://github.com/coreos/coreos-assembler).  As of today, we build it in quay.io and deliver it that way in the `quay.io/coreos-assembler` namespace.  The list of administrators for this namespace is managed independently of anything else.  If you think you need administrator access, file a ticket or ask on `#coreos:fedoraproject.org` on Matrix.
 
 ### The buildroot container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
 

--- a/docs/ci-and-builds.md
+++ b/docs/ci-and-builds.md
@@ -51,7 +51,7 @@ Examples:
 
 ## quay.io/coreos-assembler namespace
 
-A key aspect of Fedora CoreOS as well as RHEL CoreOS is [coreos-assembler](https://github.com/coreos/coreos-assembler).  As of today, we build it in quay.io and deliver it that way in the `quay.io/coreos-assembler` namespace.  The list of administrators for this namespace is managed independently of anything else.  If you think you need administrator access, file a ticket or ask on `#coreos:fedoraproject.org` on Matrix.
+A key aspect of Fedora CoreOS as well as RHEL CoreOS is [coreos-assembler](https://github.com/coreos/coreos-assembler).  As of today, we build it in quay.io and deliver it that way in the `quay.io/coreos-assembler` namespace.  The list of administrators for this namespace is managed independently of anything else.  If you think you need administrator access, file a ticket or ask on [`#coreos:fedoraproject.org` on Matrix](https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org).
 
 ### The buildroot container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
 


### PR DESCRIPTION
We'd like to direct all communications to the Matrix channel going
forward, so let's drop mentions of the IRC channel.

Related: #1566