### PR TITLE
templates/rebase: various tweaks from current walk-through

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -70,6 +70,12 @@ Branching is when a new stream is "branched" off of `rawhide`. This eventually b
 
 ## Preparing for Fedora (N) GA
 
+### Ship a final `next` release
+
+If the packages in `next-devel` don't exactly match the last `next` release that was done, we need to do a release with the final GA content. This ensures that what we'll promote to `testing` has the exact content in GA (plus version fast-tracks). This usually happens on the Thursday of the announcement of Go.
+
+- [ ] Ensure final `next` release has GA content
+
 ### Update [fedora-coreos-config](https://github.com/coreos/fedora-coreos-config/) `testing-devel`
 
 - [ ] Bump `releasever` in `manifest.yaml`

--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -51,6 +51,7 @@ Branching is when a new stream is "branched" off of `rawhide`. This eventually b
 ### Update [fedora-coreos-config](https://github.com/coreos/fedora-coreos-config/) `next-devel`
 
 - [ ] Bump `releasever` in `manifest.yaml`
+- [ ] Add the `fedora-candidate-compose` repo in `manifest.yaml` ([example PR](https://github.com/coreos/fedora-coreos-config/pull/2706))
 - [ ] Update the repos in `manifest.yaml` if needed
 - [ ] Run `cosa fetch --dry-run --update-lockfile`
     - this updates the x86_64 lockfile - the others will get updated when `bump-lockfile` runs.
@@ -95,6 +96,9 @@ We prefer to disable `next-devel` when there is no difference between `testing-d
 
 - [ ] Update [repo-templates](https://github.com/coreos/repo-templates) [config.yaml](https://github.com/coreos/repo-templates/blob/main/config.yaml) with the version number and GPG key ID for Fedora (N).
 
+### Disable the `fedora-candidate-compose` repo
+
+- [ ] Remove from the `manifest.yaml` of `next-devel` the `fedora-candidate-compose` repo
 
 ## After Fedora (N) GA
 


### PR DESCRIPTION
templates/rebase: document adding/removing `fedora-candidate-compose` repo

This is a repo that we only want during the Beta period. Make sure we
remove it otherwise.

Closes: #1602

---

templates/rebase: document final `next` release before GA

This is what we do in practice but it wasn't documented.