### PR TITLE
Remove command from meeting-people.txt

### DIFF
--- a/meeting-people.txt
+++ b/meeting-people.txt
@@ -1,8 +1,5 @@
 # List of people to ping before the Fedora CoreOS community meetings.
 # Please keep this list in alphabetical order.
-tail -n +5 $0 | tr '\n' ' ' && echo -e '\nFCOS community meeting in #meeting-1:fedoraproject.org' && echo "If you don't want to be pinged remove your name from this file: https://github.com/coreos/fedora-coreos-tracker/blob/main/meeting-people.txt"
-exit 0
-
 @aaradhak:matrix.org
 @apiaseck:matrix.org
 @davdunc:fedora.im


### PR DESCRIPTION
We are automating this now with
https://github.com/coreos/fcos-meeting-action/pull/83 so we have no need for the instructions.