### PR TITLE
Rebase checklist: add Containerfiles for kola containers

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -183,6 +183,7 @@ These are various containers in use throughout our ecosystem. We should update o
 
 - [ ] Update coreos-assembler or open ticket to update:
     - [Dockerfile](https://github.com/coreos/coreos-assembler/blob/main/Dockerfile)
+    - [Dockerfiles for kola test containers](https://github.com/coreos/coreos-assembler/tree/main/tests/containers)
 - [ ] Update coreos-installer
     - [Dockerfile](https://github.com/coreos/coreos-installer/blob/main/Dockerfile)
 - [ ] Update Ignition


### PR DESCRIPTION
Since we moved some containers that kola relied on to the coreOS pipeline, let's update the base image as well

I added it manually in https://github.com/coreos/fedora-coreos-tracker/issues/1674