### PR TITLE
templates/rebase: add rhcos extensions container update step

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -210,3 +210,5 @@ These are various containers in use throughout our ecosystem. We should update o
     - [Dockerfile](https://github.com/coreos/fedora-coreos-releng-automation/blob/main/fedora-ostree-pruner/Dockerfile)
     - [ImageStream](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/fedora-ostree-pruner/templates/imagestream.yml)
     - [BuildConfig](https://pagure.io/fedora-infra/ansible/blob/main/f/roles/openshift-apps/fedora-ostree-pruner/templates/buildconfig.yml)
+- [ ] Update RHCOS extensions container
+    - [Dockerfile](https://github.com/openshift/os/blob/master/extensions/Dockerfile)


### PR DESCRIPTION
Add a step to the Fedora Rebase Checklist to update the Fedora version in the RHCOS extensions container Dockerfile.
We recently ran into a situation where the version hadn't been updated and it caused us some issues. 
See: https://github.com/openshift/os/pull/1545 and https://github.com/openshift/os/pull/1550.

https://github.com/openshift/os/issues/1546 aims to move away from using Fedora images for RHCOS and SCOS, so we may be able to remove this step in the future.