### PR TITLE
README: fix chrome commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ you have to run your browser in a specific mode to allow the
 application to download the database and the inquiries file:
 
 ```
-chromium-browser --disable-web-security --user-data-dir ~/chrome-disable-web-security/
+chromium-browser --disable-web-security --user-data-dir=~/chrome-disable-web-security/
 # OR
-google-chrome-stable --disable-web-security --user-data-dir ~/chrome-disable-web-security/
+google-chrome-stable --disable-web-security --user-data-dir=~/chrome-disable-web-security/
 ```
 
 Now navigate to


### PR DESCRIPTION
The --user-data-dir command requires the `=` I guess because otherwise it tries to launch ~/chrome-disable-web-security/ in the browser upon running. Fixes 8c5a98b.