### PR TITLE
README: update the Fedora CoreOS Community Meeting time

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ happens in
 [#meeting-1:fedoraproject.org](https://matrix.to/#/#meeting-1:fedoraproject.org)
 on Matrix and the schedule for the meeting can be found here:
 https://calendar.fedoraproject.org/CoreOS/ Currently, meetings are at
-[`16:30 UTC`](https://time.is/16:30+UTC) on Wednesdays.
+[`15:30 UTC`](https://time.is/15:30+UTC) on Wednesdays.
 
 As the
 [Matrix bridge to Libera Chat is shutdown](https://matrix.org/blog/2023/11/28/shutting-down-bridge-to-libera-chat/),


### PR DESCRIPTION
It was decided in the community meeting on `2025-06-25` to move the meeting time one hour earlier to accomodate more members.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1972