### PR TITLE
templates/rebase: also update the cosa ci-operator buildroot image

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase.md
+++ b/.github/ISSUE_TEMPLATE/rebase.md
@@ -190,6 +190,7 @@ These are various containers in use throughout our ecosystem. We should update o
 - [ ] Update coreos-assembler or open ticket to update:
     - [Dockerfile](https://github.com/coreos/coreos-assembler/blob/main/Dockerfile)
     - [Dockerfiles for kola test containers](https://github.com/coreos/coreos-assembler/tree/main/tests/containers)
+    - [Dockerfile for the OpenShift CI buildroot image](https://github.com/openshift/release/blob/master/ci-operator/config/coreos/coreos-assembler/coreos-coreos-assembler-main.yaml)
 - [ ] Update coreos-installer
     - [Dockerfile](https://github.com/coreos/coreos-installer/blob/main/Dockerfile)
 - [ ] Update Ignition


### PR DESCRIPTION
Document this step so we remember to update it with each fedora major release.